### PR TITLE
Increase delay in updating machine state.

### DIFF
--- a/config/Mekanism.cfg
+++ b/config/Mekanism.cfg
@@ -26,7 +26,7 @@ general {
     B:BlacklistIC2Power=false
     B:BlacklistRFPower=false
     B:BlacklistTeslaPower=true
-    I:ClientUpdateDelay=10
+    I:ClientUpdateDelay=40
     B:ControlCircuitOreDict=false
     I:CopperPerChunk=30
     B:DestroyDisabledBlocks=true


### PR DESCRIPTION
Default is 10 ticks. Changed to 40 ticks (2 seconds). Another config option which can save client performance when Mek machines are going active/inactive rapidly like in ore processing. Results in slower visual changes, but theoretically the higher we set this the better the performance is. If it's not sufficient we can increase it further. Config change required on both client and server.