### PR TITLE
EnderIO Config Tweaks

### DIFF
--- a/config/enderio/EnderIO.cfg
+++ b/config/enderio/EnderIO.cfg
@@ -525,7 +525,7 @@
     B:itemConduitUsePhyscialDistance=false
 
     # The cost in RF of transporting a bucket of fluid via a Dimensional Transceiver.
-    I:transceiverBucketTransmissionCostRF=100
+    I:transceiverBucketTransmissionCostRF=0
 
     # When true: correct lighting is recalculated (client side) for conduit bundles when transitioning to from being hidden behind a facade. This produces better quality rendering but can result in frame stutters when switching to/from a wrench.
     B:updateLightingWhenHidingFacades=false
@@ -777,7 +777,7 @@ inventorypanel {
     B:travelAnchorEnabled=true
 
     # If travelStaffBlinkThroughSolidBlocksEnabled is set to false and this is true: the travel staff can only be used to blink through transparent or partial blocks (e.g. torches). If both are false: only air blocks may be teleported through.
-    B:travelStaffBlinkThroughClearBlocksEnabled=true
+    B:travelStaffBlinkThroughClearBlocksEnabled=false
 
     # Allows the travel staff to blink through unbreakable blocks such as warded blocks and bedrock.
     B:travelStaffBlinkThroughUnbreakableBlocksEnabled=false
@@ -870,23 +870,23 @@ inventorypanel {
     B:magnetAllowInMainInventory=false
 
     # The BaublesType the magnet should be, 'AMULET', 'RING' or 'BELT' (requires Baubles to be installed and magnetAllowInBaublesSlot to be on)
-    S:magnetBaublesType=AMULET
+    S:magnetBaublesType=RING
 
     # These items will not be picked up by the magnet. [default: [appliedenergistics2:item.ItemCrystalSeed], [Botania:livingrock], [Botania:manaTablet]]
     S:magnetBlacklist <
-        appliedenergistics2:item.ItemCrystalSeed
-        Botania:livingrock
-        Botania:manaTablet
+        appliedenergistics2:crystal_seed
+        botania:livingrock
+        botania:manaTablet
      >
 
     # Maximum number of items the magnet can effect at a time. (-1 for unlimited)
     I:magnetMaxItems=20
 
     # Amount of RF power stored in a fully charged magnet
-    I:magnetPowerCapacityRF=100000
+    I:magnetPowerCapacityRF=1
 
     # The amount of RF power used per tick when the magnet is active
-    I:magnetPowerUsePerTickRF=1
+    I:magnetPowerUsePerTickRF=0
 
     # Range of the magnet in blocks.
     I:magnetRange=5
@@ -922,7 +922,7 @@ misc {
     S:xpJuiceName=xpjuice
 
     # Maximum level of XP the xp obelisk can contain.
-    I:xpObeliskMaxXpLevel=2147483647
+    I:xpObeliskMaxXpLevel=65535000
 }
 
 
@@ -973,7 +973,7 @@ misc {
     B:jeiUseShortenedPainterRecipes=true
 
     # Volume of machine sounds.
-    D:machineSoundVolume=1.0
+    D:machineSoundVolume=0.5
 
     # Can be used to disable the 'shrinking' effect of the telepad in case of conflicts with other mods.
     B:telepadShrinkEffect=true
@@ -985,10 +985,10 @@ misc {
     B:useMachineSounds=true
 
     # If true, shift-mouse wheel will change the conduit display mode when the YetaWrench is equipped.
-    B:useSneakMouseWheelYetaWrench=true
+    B:useSneakMouseWheelYetaWrench=false
 
     # If true, shift-clicking the YetaWrench on a null or non wrenchable object will change the conduit display mode.
-    B:useSneakRightClickYetaWrench=false
+    B:useSneakRightClickYetaWrench=true
 
     # The chance per looting level that a skull will be dropped when using a non-dark steel sword (0 = no chance, 1 = 100% chance)
     D:vanillaSwordSkullLootingModifier=0.05000000074505806
@@ -1087,14 +1087,14 @@ misc {
     S:soulBinderLevelOnePowerPerTickRF.scaler=QUADRATIC
 
     # Amount of energy lost when transfered by Dimensional Transceiver; 0 is no loss, 1 is 100% loss
-    D:transceiverEnergyLoss=0.1
+    D:transceiverEnergyLoss=0.0
 
     # enderio.config.capacitor.transceiverMaxIoRF
-    I:transceiverMaxIoRF=40960
+    I:transceiverMaxIoRF=2147483647
     S:transceiverMaxIoRF.scaler=FIXED_1
 
     # enderio.config.capacitor.transceiverUpkeepCostRF
-    I:transceiverUpkeepCostRF=10
+    I:transceiverUpkeepCostRF=0
     S:transceiverUpkeepCostRF.scaler=FIXED_1
 
     # Power use (RF/t) used by the vat.
@@ -1134,7 +1134,7 @@ misc {
     I:poweredSpawnerMaxNearbyEntities=6
 
     # Max distance of the closest player for the spawner to be active. A zero value will remove the player check
-    I:poweredSpawnerMaxPlayerDistance=0
+    I:poweredSpawnerMaxPlayerDistance=2
 
     # Number of tries to find a suitable spawning location
     I:poweredSpawnerMaxSpawnTries=3
@@ -1191,7 +1191,7 @@ rail {
     D:enchanterLapisCostFactor=3.0
 
     # The final XP cost for an enchantment is multiplied by this value. To halve costs set to 0.5, to double them set it to 2
-    D:enchanterLevelCostFactor=0.75
+    D:enchanterLevelCostFactor=2
 
     # A comma-seperated list of durations in seconds. For these, self-reseting levers will be created. Set to 0 to disable the lever. Please note that you also need to supply a resource pack with matching blockstates and a language file for this to work. [default: 10,30,60,300]
     S:leversEnabled=10,30,60,300
@@ -1303,7 +1303,7 @@ rail {
     B:travelStaffBlinkEnabled=true
 
     # Minimum number of ticks between 'blinks'. Values of 10 or less allow a limited sort of flight.
-    I:travelStaffBlinkPauseTicks=10
+    I:travelStaffBlinkPauseTicks=20
 
     # If set to false: the travel staff can be used to blink through any block.
     B:travelStaffBlinkThroughSolidBlocksEnabled=true
@@ -1336,10 +1336,10 @@ rail {
 
 telepad {
     # If true, the coordinates cannot be set via the GUI, the coord selector must be used.
-    B:lockCoords=true
+    B:lockCoords=false
 
     # If true, the dimension cannot be set via the GUI, the coord selector must be used.
-    B:lockDimension=true
+    B:lockDimension=false
 
     # Power for a teleport is calculated by the formula:
     # power = [this value] * ln(0.005*distance + 1)


### PR DESCRIPTION
- Remove cost on Dim Transceiver usage. Max RF IO set to max INT (2b)
- Remove Staff of Travel ability to blink through blocks, except to anchors. (i think)
- Move Magnet to RING bauble slot, remove RF usage to make competitive with Botania. Update item names for default magnet blacklisted items
- Nerf XP Obelisk to only hold as much liquid XP as theoretical bedrockium drum.
- Machine sounds reduced to half volume.
- Yeta Wrench changed to shift-click on air/non-wrenchable to change display modes instead of scroll wheel to prevent accidentally hiding conduits.
- Added 2 block player distance check deadzone to powered spawner. Prevents people from getting spawned on immediately when placing an active spawner with power.
- Double XP costs on Enchanter.
- 1 Second cooldown on travel staff blinks.
- Allow manual input of coords on telepad. Makes up for lacking Matter Overdrive teleporter.