### PR TITLE
Deep Resonance Buff

### DIFF
--- a/config/deepresonance/machines.cfg
+++ b/config/deepresonance/machines.cfg
@@ -11,7 +11,7 @@ collector {
 
 crystalizer {
     # The amount of RCL that is needed for one crystal [range: 10 ~ 100000, default: 6000]
-    I:rclPerCrystal=6000
+    I:rclPerCrystal=2000
 
     # The amount of RCL/t that is consumed during crystalizing [range: 1 ~ 100000, default: 1]
     I:rclPerTick=1
@@ -71,10 +71,10 @@ plateblock {
 
 power {
     # The maximum kilo-RF (per 1000, so 1000 = 1milion RF) that a crystal with 100% power can hold [range: 1 ~ 2000000000, default: 1000000]
-    I:maximumKiloRF=1000000
+    I:maximumKiloRF=1500000
 
     # The maximum RF/tick that a crystal with 100% efficiency can give [range: 0 ~ 20000, default: 20000]
-    I:maximumRFPerTick=20000
+    I:maximumRFPerTick=30000
 }
 
 


### PR DESCRIPTION
- One third as much ore required to create a crystal. Results in cheaper crystals to feed infusing laser, and less catalysts uses in infusing laser.
- 50% boost to maximum power and maximum RF/t of crystals.