### PR TITLE
Disable ResourcefulCrops seed bags.

### DIFF
--- a/config/ResourcefulCrops/ResourcefulCrops.cfg
+++ b/config/ResourcefulCrops/ResourcefulCrops.cfg
@@ -11,7 +11,7 @@ balance {
     B:enableFakePlayerMining=true
 
     # Allows registering of seed pouches. These plant a 3x3 (9 total) seeds around a central block. [default: true]
-    B:enableSeedPouches=true
+    B:enableSeedPouches=false
 }
 
 
@@ -49,7 +49,7 @@ compat {
 
 crafting {
     # Allows crafting of seeds into pouches. Disable if you wish to use custom recipes. [default: true]
-    B:enablePouchCrafting=true
+    B:enablePouchCrafting=false
 
     # Allows crafting of materials into seeds. Disable if you wish to use custom recipes. [default: true]
     B:enableSeedCrafting=true


### PR DESCRIPTION
- Disables the seeds bags. Borderline useless, no one uses them. Saves on registered items in JEI.