### PR TITLE
Draconic Evolution Tweaks

### DIFF
--- a/config/brandon3055/DraconicEvolution.cfg
+++ b/config/brandon3055/DraconicEvolution.cfg
@@ -162,7 +162,7 @@ items {
 
 tweaks {
     # Set to false to prevent the bows explosion effect breaking blocks
-    B:bowBlockDamage=true
+    B:bowBlockDamage=false
 
     # (Wuss mode) Setting this to true will disable the chaos guardians ability to respawn healing crystals.
     B:disableGuardianCrystalRespawn=false
@@ -198,7 +198,7 @@ tweaks {
 
 world {
     # This is the distance between chaos islands
-    I:chaosIslandSeparation=10000
+    I:chaosIslandSeparation=5000
 
     # Ender Comets have a 1 in {this number} chance to spawn in each chunk
     I:cometRarity=10000


### PR DESCRIPTION
- Disable block damage from bow explosions
- Chaos Islands at 5k instead of 10k so people can fly less and generate fewer chunks.