### PR TITLE
RFTools Tweaks / Quarry Nerf

### DIFF
--- a/config/rftools/rftools.cfg
+++ b/config/rftools/rftools.cfg
@@ -68,7 +68,7 @@ builder {
     I:builderRfPerPlayer=40000
 
     # Base RF per block operation for the builder when used as a quarry or voider (actual cost depends on hardness of block)
-    I:builderRfPerQuarry=300
+    I:builderRfPerQuarry=900
 
     # RF per block that is skipped (used when a filter is added to the builder)
     I:builderRfPerSkipped=50
@@ -92,7 +92,7 @@ builder {
     D:dimensionCostFactor=5.0
 
     # The RF per operation of the builder is multiplied with this factor when using the fortune quarry shape card
-    D:fortunequarryShapeCardFactor=2.0
+    D:fortunequarryShapeCardFactor=6.0
 
     # Maximum dimension of the shape when a shape card is used in the builder
     I:maxBuilderDimension=512
@@ -110,7 +110,7 @@ builder {
     B:quarryAllowed=true
 
     # The base speed (number of blocks per tick) of the quarry
-    I:quarryBaseSpeed=8
+    I:quarryBaseSpeed=4
 
     # If true the quarry will chunkload a chunk at a time. If false the quarry will stop if a chunk is not loaded
     B:quarryChunkloads=true
@@ -131,7 +131,7 @@ builder {
     B:showProgressHud=true
 
     # The RF per operation of the builder is multiplied with this factor when using the silk quarry shape card
-    D:silkquarryShapeCardFactor=3.0
+    D:silkquarryShapeCardFactor=9.0
 
     # Maximum RF storage that the space projector can hold
     I:spaceProjectorMaxRF=100000
@@ -143,7 +143,7 @@ builder {
     S:tileEntityMode=whitelist
 
     # The RF per operation of the builder is multiplied with this factor when using the void shape card
-    D:voidShapeCardFactor=0.5
+    D:voidShapeCardFactor=0.05
 }
 
 


### PR DESCRIPTION
- Triple base energy cost of Builder in quarry mode.
- Triple penalties for Silk and Fortune in quarry mode.
- Reduce cost in void mode to 5% of normal to make noobs clearing flat land for base easier.
- Reduce base speed of quarry by half.