### PR TITLE
Fancy Fluid Storage buffed again.

### DIFF
--- a/config/FFS.cfg
+++ b/config/FFS.cfg
@@ -15,7 +15,7 @@ general {
 
     # How many millibuckets can each block within the tank store? (Has to be higher than 1!)
     # Default: 16000
-    I:mbPerVirtualTank=64000
+    I:mbPerVirtualTank=256000
 
     # The amount of energy loss you have when you extract energy / metaphased flux from the tank.
     # Default: 10
@@ -31,7 +31,7 @@ general {
 
     # Should tank capacity only count the interior air blocks, rather than including the frame?
     # Default: true
-    B:onlyCountInsideCapacity=true
+    B:onlyCountInsideCapacity=false
 
     # Do you want to set the world on fire? Or do you just want to create a flame in my heart?
     # (Don't worry, this is harmless :))
@@ -40,7 +40,7 @@ general {
 
     # Should tanks with leaky materials start leaking randomly?
     # Default: true
-    B:shouldTanksLeak=true
+    B:shouldTanksLeak=false
 
     # Declare which mode you want the tank frames to be.
     # 0 = Only the same block with the same metadata is allowed
@@ -51,7 +51,7 @@ general {
 
     # Should tanks only render the inside as fluid or extend to the frame-sides?
     # Default: true
-    B:tanksRenderInsideOnly=true
+    B:tanksRenderInsideOnly=false
 }
 
 


### PR DESCRIPTION
- 256000mB per block. If it's not at least on par with the basic drums on a per-block basis its not really competitive. FFS rarely used as it is.
- Counts frame blocks for capacity. Makes smaller tanks not completely useless.
- Adjust render setting to account for frame blocks counting towards capacity.