### PR TITLE
Buff IC2 nuclear power to 3x. Disable hidden recipes.

### DIFF
--- a/config/IC2.ini
+++ b/config/IC2.ini
@@ -81,7 +81,7 @@ water = 1.0
 solar = 1.0
 ; Deprecated, because of Kinetic Windmill
 wind = 1.0
-nuclear = 1.0
+nuclear = 3.0
 semiFluidOil = 1.0
 semiFluidFuel = 1.0
 semiFluidBiomass = 1.0
@@ -181,7 +181,7 @@ enableIc2Audio = true
 ; Maximum number of active audio sources, only change it if you know what you're doing.
 maxAudioSourceCount = 32
 ; Enable hiding of secret recipes in CraftGuide/NEI.
-hideSecretRecipes = true
+hideSecretRecipes = false
 ; Enable activation of the quantum leggings' speed boost when sprinting instead of holding the boost key.
 quantumSpeedOnSprint = true
 ; Enable burning of scrap in a generator.


### PR DESCRIPTION
- Buffed IC2 nuclear power to 3.0 multiplier.
- IC2's weird recipe hiding thingy turned off.