### PR TITLE
Disable Chisel durability in Chisel.

### DIFF
--- a/config/chisel.cfg
+++ b/config/chisel.cfg
@@ -17,7 +17,7 @@ chisel {
     B:allowChiselCrossColors=true
 
     # Should the chisel be damageable and take damage when it chisels something.
-    B:allowChiselDamage=true
+    B:allowChiselDamage=false
 
     # The extra attack damage points (in half hearts) that the diamond chisel inflicts when it is used to attack an entity.
     I:diamondChiselAttackDamage=3


### PR DESCRIPTION
- Disable durability for Chisels. Annoying but doesn't add a significant material sink. Aesthetic tool.