### PR TITLE
Disable C&B chisel damage.

### DIFF
--- a/config/chiselsandbits.cfg
+++ b/config/chiselsandbits.cfg
@@ -1,10 +1,10 @@
 # Configuration file
 
 "balance settings" {
-    I:bagStackSize=512
+    I:bagStackSize=2048
     D:bitLightPercentage=6.25
     B:compatabilityMode=true
-    B:damageTools=true
+    B:damageTools=false
     I:diamondChiselUses=796480
     I:diamondSawUses=7980
     B:enableBitLightSource=true


### PR DESCRIPTION
- Disable durability on tools. C&B annoying enough as-is.
- Increase bit bag capacity by 4x. Default is barely enough for like 2 blocks worth of bits.