### PR TITLE
Dark Utils Tweaks

### DIFF
--- a/config/darkutils.cfg
+++ b/config/darkutils.cfg
@@ -116,7 +116,7 @@ ender_hopper {
 
 ender_tether {
     # Should the Ender Tether catch players using ender teleportation? [default: true]
-    B:"Affect Players"=true
+    B:"Affect Players"=false
 
     # Should the Ender Tether be craftable? [default: true]
     B:Craftable=true
@@ -311,7 +311,7 @@ vector_plate {
     S:"Normal Speed"=0.06
 
     # Should vector plates prevent item despawn? [default: true]
-    B:"Prevent Item Despawn"=true
+    B:"Prevent Item Despawn"=false
 
     # Should vector plates prevent items from being picked up, while they are being pushed? [default: true]
     B:"Prevent Item Pickup"=true


### PR DESCRIPTION
- Disabled Ender Tether working on players.
- Let items on vector plates despawn. Prevents scary lag scenario.