### PR TITLE
Cyberware Balance - First Pass

### DIFF
--- a/config/cyberware.cfg
+++ b/config/cyberware.cfg
@@ -77,19 +77,19 @@ gamerules {
     B:"Default for gamerule cyberware_dropCyberware"=false
 
     # Determines if players keep their Cyberware between lives. Does not change settings on existing worlds, use /gamerule for that. [default: false]
-    B:"Default for gamerule cyberware_keepCyberware"=false
+    B:"Default for gamerule cyberware_keepCyberware"=true
 }
 
 
 machines {
     #  [range: 0.0 ~ 100.0, default: 10.0]
-    S:"Additive chance for Scanner per extra item"=10.0
+    S:"Additive chance for Scanner per extra item"=5.0
 
     #  [range: 0.0 ~ 100.0, default: 15.0]
-    S:"Chance of blueprint from Engineering Table"=15.0
+    S:"Chance of blueprint from Engineering Table"=5.0
 
     #  [range: 0.0 ~ 100.0, default: 10.0]
-    S:"Chance of blueprint from Scanner"=10.0
+    S:"Chance of blueprint from Scanner"=5.0
 
     # 24000 is one Minecraft day, 1200 is one real-life minute [range: 0 ~ 2147483647, default: 24000]
     I:"Ticks taken per Scanner operation"=24000
@@ -101,16 +101,16 @@ mobs {
     B:"Disable cyberzombies"=false
 
     # Vanilla Zombie = 4, Enderman = 4, Witch = 1 [range: 0 ~ 2147483647, default: 1]
-    I:"Maximum Cyberzombie pack size"=1
+    I:"Maximum Cyberzombie pack size"=4
 
     # Vanilla Zombie = 4, Enderman = 1, Witch = 1 [range: 0 ~ 2147483647, default: 1]
-    I:"Minimum Cyberzombie pack size"=1
+    I:"Minimum Cyberzombie pack size"=4
 
     #  [range: 0.0 ~ 100.0, default: 50.0]
-    S:"Percent chance a Cyberzombie drops an item"=50.0
+    S:"Percent chance a Cyberzombie drops an item"=10.0
 
     # Vanilla Zombie = 100, Enderman = 10, Witch = 5 [range: 0 ~ 2147483647, default: 15]
-    I:"Spawning weight of Cyberzombies"=15
+    I:"Spawning weight of Cyberzombies"=10
 }
 
 
@@ -125,7 +125,7 @@ other {
     B:"Enable crafting recipe for Robosurgeon"=false
 
     #  [range: 0 ~ 2147483647, default: 1]
-    I:"RF/Tesla per internal power unit"=1
+    I:"RF/Tesla per internal power unit"=16
 }
 
 


### PR DESCRIPTION
- Players now keep cyberware when dying instead of permanently losing it. (Idea is to make it harder to obtain, rather than easier to lose.)
- Reduce chance of getting a blue print from scanner or engineeering table.
- Increased power usage from 1 RF per internal power unit to 16 RF.
- Increase minimum cyberzombie pack size to 4.
- Slightly lower natural spawning chance of cyberzombie.