### PR TITLE
Cyberware Balance - EIO Spawner Blacklist

### DIFF
--- a/config/enderio/PoweredSpawnerConfig_Core.json
+++ b/config/enderio/PoweredSpawnerConfig_Core.json
@@ -45,6 +45,7 @@
 
   "blackList": [
     "VillagerGolem",
-    "Villager"
+    "Villager",
+    "Cyberzombie"
   ]
 }


### PR DESCRIPTION
- Blacklist Cyberzombies in EIO spawner. Mod has its own way to summon more.