### PR TITLE
Cyberware Balance - Infernal Mobs

### DIFF
--- a/config/InfernalMobs.cfg
+++ b/config/InfernalMobs.cfg
@@ -5,6 +5,7 @@ entitiesalwaysinfernal {
     B:EntityBlueSlime=false
     B:EntityConcussionCreeper=false
     B:EntityCreeper=false
+    B:EntityCyberZombie=true
     B:EntityDweller=false
     B:EntityEnderman=false
     B:EntityFallenKnight=false
@@ -25,7 +26,7 @@ entitybasehealth {
     D:EntityBlueSlime=2.504469156265259
     D:EntityConcussionCreeper=9.207293510437012
     D:EntityCreeper=43.05422592163086
-    D:EntityCyberZombie=11.685486793518066
+    D:EntityCyberZombie=23
     D:EntityFallenKnight=11.628152847290039
     D:EntityGuardian=65.94145965576172
     D:EntityPirate=20.0


### PR DESCRIPTION
- Cyberzombies always infernal.
- Cyberzombie base health doubled.