### PR TITLE
RFTools Spawner Blacklist

### DIFF
--- a/config/rftools/rftools.cfg
+++ b/config/rftools/rftools.cfg
@@ -723,24 +723,6 @@ mobspawnamounts {
         0
         20.0
      >
-    S:EnderDragon.spawnamount.0 <
-        I
-        minecraft:experience_bottle
-        0
-        0.1
-     >
-    S:EnderDragon.spawnamount.1 <
-        B
-        minecraft:end_stone
-        0
-        100.0
-     >
-    S:EnderDragon.spawnamount.2 <
-        L
-        
-        0
-        200.0
-     >
     S:Enderman.spawnamount.0 <
         I
         minecraft:ender_pearl
@@ -1173,24 +1155,6 @@ mobspawnamounts {
         0
         30.0
      >
-    S:WitherBoss.spawnamount.0 <
-        I
-        minecraft:nether_star
-        0
-        0.1
-     >
-    S:WitherBoss.spawnamount.1 <
-        B
-        minecraft:soul_sand
-        0
-        0.5
-     >
-    S:WitherBoss.spawnamount.2 <
-        L
-        
-        0
-        100.0
-     >
     S:WitherSkeleton.spawnamount.0 <
         I
         minecraft:bone
@@ -1261,7 +1225,6 @@ mobspawnrf {
     I:Chicken=500
     I:Cow=800
     I:Creeper=800
-    I:EnderDragon=100000
     I:Enderman=2000
     I:Endermite=400
     I:EntityHorse=1000
@@ -1286,7 +1249,6 @@ mobspawnrf {
     I:Villager=2000
     I:VillagerGolem=2000
     I:Witch=1200
-    I:WitherBoss=20000
     I:WitherSkeleton=1500
     I:Wolf=800
     I:Zombie=800


### PR DESCRIPTION
- Removed Ender Dragon and Wither boss from spawner config. This should prevent spawning them.