### PR TITLE
Geographicraft Worldgen Tweaks

### DIFF
--- a/config/GeographiCraft/geographicraft.cfg
+++ b/config/GeographiCraft/geographicraft.cfg
@@ -14,7 +14,7 @@
     I:"Biome Size"=4
 
     # per thousand; vanilla is 10
-    I:"Mushroom Island Incidence"=10
+    I:"Mushroom Island Incidence"=30
 
     # generate as if CC weren't on; for loading pre-existing worlds or just preventing chunk boundaries
     B:"No Generation Changes"=false
@@ -90,13 +90,13 @@
     I:"Cool Zone Incidence"=1
 
     # relative incidence of hot zones like savanna/desert/plains/mesa
-    I:"Hot Zone Incidence"=1
+    I:"Hot Zone Incidence"=4
 
     # relative incidence of snowy zones
     I:"Snowy Zone Incidence"=1
 
     # relative incidence of warm zones like forest/plains/hills/jungle/swamp
-    I:"Warm Zone Incidence"=1
+    I:"Warm Zone Incidence"=2
 }
 
 
@@ -123,7 +123,7 @@
     B:"Random Biomes"=false
 
     # Number of climate zones to shift the band from the default of the warm - to - cool transition at 0. Positive numbers shift the bands up.
-    I:bandedClimateOffset=0
+    I:bandedClimateOffset=1
 
     # Width of banded climates (climate depends on latitude). 0 or less for normal rules. Width is in terms of climate zones, whatever they are
     I:bandedClimateWidth=-1
@@ -147,16 +147,19 @@
     I:"Incidence of Continents,Large"=0
 
     # frequency of medium continent seeds, about 4000x8000
-    I:"Incidence of Continents,Medium"=60
+    I:"Incidence of Continents,Medium"=120
 
     # frequency of small continent seeds, about 2000x4000
-    I:"Incidence of Continents,Small"=120
+    I:"Incidence of Continents,Small"=240
 
     # frequency of large island seeds, about 500x1000
-    I:"Incidence of Islands,Large"=60
+    I:"Incidence of Islands,Large"=120
 
     # frequency of medium island seeds, about 250x500, but they tend to break up into archipelagos
-    I:"Incidence of Islands,Medium"=30
+    I:"Incidence of Islands,Medium"=60
+    
+    # Rounds of continent and large island expansion in oceanic worlds (with separateLandmasses off). More makes continents larger and oceans narrower. Default is 1.
+    I:"Land Expansion Rounds"=5
 
     # True mostly stops landmasses merging.With default settings you will get an oceanic world if true and a continental world if false
     B:SeparateLandmasses=true


### PR DESCRIPTION
- Move climate bands up one to make spawn a bit warmer.
- Increase incidence of warm and hot climates to help with too many snow biomes.
- Increase incidence of all continent and island types.
- More mushroom island.