### PR TITLE
Update IE wire and capacitor limits

### DIFF
--- a/config/immersiveengineering.cfg
+++ b/config/immersiveengineering.cfg
@@ -83,9 +83,9 @@ general {
         32
      >
     D:wireLossRatio <
-        0.05
-        0.025
-        0.025
+        0.0
+        0.0
+        0.0
         1.0
         1.0
         1.0
@@ -106,14 +106,14 @@ general {
         I:arcfurnace_electrodeDamage=96000
         B:arcfurnace_recycle=true
         I:assembler_consumption=80
-        I:capacitorHV_input=4096
-        I:capacitorHV_output=4096
+        I:capacitorHV_input=32768
+        I:capacitorHV_output=32768
         I:capacitorHV_storage=4000000
-        I:capacitorLV_input=256
-        I:capacitorLV_output=256
+        I:capacitorLV_input=2048
+        I:capacitorLV_output=2048
         I:capacitorLV_storage=100000
-        I:capacitorMV_input=1024
-        I:capacitorMV_output=1024
+        I:capacitorMV_input=8192
+        I:capacitorMV_output=8192
         I:capacitorMV_storage=1000000
         I:charger_consumption=256
         I:coredrill_consumption=40


### PR DESCRIPTION
Removed distance loss for IE wires, since nothing else in the pack has that remaining. Updated IE capacitors to match the throughput possibility of the already previously raised wires, so using IE capacitors doesn't drastically reduce the amount of power transferred. They had previously not been updated, and so were at 1/8 the transfer rate of their respective cables.