### PR TITLE
Increase Cobalt and Ardite ore in Nether.

### DIFF
--- a/config/tconstruct.cfg
+++ b/config/tconstruct.cfg
@@ -91,8 +91,8 @@ worldgen {
     B:genArdite=true
 
     # Approx Ores per chunk
-    I:cobaltRate=20
-    I:arditeRate=20
+    I:cobaltRate=30
+    I:arditeRate=30
 }
 
 


### PR DESCRIPTION
- Compensate for lack of easy doubling of these by increasing by 50%