### PR TITLE
[Ender IO] Enchanter & Telepad Tweak

### DIFF
--- a/config/enderio/EnderIO.cfg
+++ b/config/enderio/EnderIO.cfg
@@ -1413,7 +1413,7 @@ rail {
     D:enchanterLapisCostFactor=3.0
 
     # The final XP cost for an enchantment is multiplied by this value. To halve costs set to 0.5, to double them set it to 2
-    D:enchanterLevelCostFactor=2
+    D:enchanterLevelCostFactor=1.25
 
     # A comma-seperated list of durations in seconds. For these, self-reseting levers will be created. Set to 0 to disable the lever. Please note that you also need to supply a resource pack with matching blockstates and a language file for this to work. [default: 10,30,60,300]
     S:leversEnabled=10,30,60,300
@@ -1435,7 +1435,7 @@ rail {
     I:rodOfReturnFluidStorage=200
 
     # The type of fluid used by the rod. [default: ender_distillation]
-    S:rodOfReturnFluidType=ender_distillation
+    S:rodOfReturnFluidType=nutrient_distillation
 
     # How much fluid is used per teleport
     I:rodOfReturnFluidUsePerTeleport=200


### PR DESCRIPTION
Reduced the Enchanter nerf from 2x to 1.25x.
Changed telepad fluid to easier Nutrient Distillation.