### PR TITLE
[Xtones] Disable recipes.

### DIFF
--- a/config/xtones.cfg
+++ b/config/xtones.cfg
@@ -13,7 +13,7 @@ general {
 
     # Disables all recipes except the one for the Stone Tile.
     # Mainly for use with Chisel installed and chiselMode being set to 0.
-    B:disableXtoneRecipes=false
+    B:disableXtoneRecipes=true
 }
 
 


### PR DESCRIPTION
Chisel used instead to switch types from base block.